### PR TITLE
add autoloader for namespacing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,10 @@
     },
     "require-dev": {
         "phpunit/phpunit": "4.6.*"
+    },
+    "autoload":{
+       "psr-4":{
+          "Torpedo\\":"fastpress/torpedo/lib"
+       }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "autoload":{
        "psr-4":{
-          "Torpedo\\":"fastpress/torpedo/lib"
+          "Torpedo\\":"lib"
        }
     }
 }


### PR DESCRIPTION
Ok, so when I create fastpress project 
```bash
$ composer create-project fastpress/fastpress:0.1.0
```
All works fine, except there is no namespace for autoload torpedo libraries. 
This is what I get in `/fastpress/vendor/composer/autoload_ps4.php`
```php
return array(
    'Symfony\\Component\\Yaml\\' => array($vendorDir . '/symfony/yaml'),
    'Doctrine\\Instantiator\\' => array($vendorDir . '/doctrine/instantiator/src/Doctrine/Instantiator'),
    'DeepCopy\\' => array($vendorDir . '/myclabs/deep-copy/src/DeepCopy'),
    'App\\Model\\' => array($baseDir . '/src/app/model'),
    'App\\Controller\\' => array($baseDir . '/src/app/controller'),
);
```
See, there is no mention of torpedo. So, I am adding the autoload to this composer file to fix the problem. I hope this was not confusing :)
